### PR TITLE
Rename Nostrand to NostrandMain for mac build

### DIFF
--- a/Magic.csproj
+++ b/Magic.csproj
@@ -8,8 +8,8 @@
         <NostrandCloneString>master https://github.com/nasser/nostrand.git</NostrandCloneString>
     </PropertyGroup>
     <PropertyGroup>
-        <NostrandExeNet4x>nostrand/bin/x64/Release/net471/Nostrand.exe</NostrandExeNet4x>
-        <NostrandExeNet5>nostrand/bin/x64/Release/net5.0/Nostrand.dll</NostrandExeNet5>
+        <NostrandExeNet4x>nostrand/bin/Release/net471/NostrandMain.exe</NostrandExeNet4x>
+        <NostrandExeNet5>nostrand/bin/Release/net5.0/NostrandMain.dll</NostrandExeNet5>
         <MagicUnityInfrastructureExport>magic.unity/Infrastructure/Export</MagicUnityInfrastructureExport>
         <ClojureRuntimeDllNet471>clojure.runtime/bin/Release/net471/Clojure.dll</ClojureRuntimeDllNet471>
         <ClojureRuntimeDllNetStandard>clojure.runtime/bin/Release/netstandard2.0/Clojure.dll</ClojureRuntimeDllNetStandard>
@@ -43,6 +43,9 @@
     <Target Name="Nostrand" DependsOnTargets="ClojureRuntime;MagicRuntime" Condition="!Exists('$(NostrandExeNet4x)') Or !Exists('$(NostrandExeNet5)')" >
         <Copy SourceFiles="$(ClojureRuntimeDllNet471);$(ClojureRuntimeDllNetStandard)" DestinationFiles="$(NostrandClojureReferenceNet4x);$(NostrandClojureReferenceNetStandard)" />
         <Copy SourceFiles="$(MagicRuntimeDllNet471);$(MagicRuntimeDllNetStandard)" DestinationFiles="$(NostrandMagicRuntimeReferenceNet4x);$(NostrandMagicRuntimeReferenceNetStandard)" />
+        <Move SourceFiles="nostrand/Nostrand.csproj" DestinationFiles="nostrand/NostrandMain.csproj" OverwriteReadOnlyFiles="true" />
+        <Copy SourceFiles="Scripts/nos-framework" DestinationFiles="nostrand/Scripts/nos-framework" OverwriteReadOnlyFiles="true" />
+        <Delete Files="nostrand/Nostrand.sln"/>
         <Exec WorkingDirectory="nostrand" Command="dotnet build -c Release" />
     </Target>
     <Target Name="Magic" DependsOnTargets="Nostrand" Condition="!Exists('$(MagicBoostrap)')">

--- a/Scripts/nos-framework
+++ b/Scripts/nos-framework
@@ -1,0 +1,5 @@
+#!/bin/bash
+ACTUAL_PATH=`dirname "$0"`
+LINKED_PATH=`readlink "$0"`
+ASSEMBLY_PATH=$([ "$LINKED_PATH" ] && echo `dirname "$LINKED_PATH"` || echo "$ACTUAL_PATH")
+mono $ASSEMBLY_PATH/NostrandMain.exe "$@"


### PR DESCRIPTION
Closes #1
---

Renaming `Nostrand` to `NostrandMain` fixed the `copy` issue (file already exists error).

Path issue on mac solution found in the [Monolith MAGIC Build Pipeline](https://github.com/flybot-sg/new-magic) by robertluo.

I had to rename `Nostrand.csproj` to `NostrandMain.csproj`  and update the `nos` scripts with the new name as well.
This is done before building nostrand.

It works now on mac.
Please be sure it still works on Linux before merging.

```
~/workspaces/magic:nostrand/bin/Release/net471/nos version 
Nostrand 1.0.0+e6ab32d3
Clojure.Runtime 1.10.0.0+3bd47b31
Magic.Runtime 1.0.0+33e9131a
Clojure 1.10.0-master-SNAPSHOT
```